### PR TITLE
Cloning now reduces your base genetic stability

### DIFF
--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -95,6 +95,7 @@ var/global/list/bad_blocks[0]
 
 	// New stuff
 	var/species = "Human"
+	var/base_stability = DEFAULT_GENE_STABILITY
 
 // Make a copy of this strand.
 // USE THIS WHEN COPYING STUFF OR YOU'LL GET CORRUPTION!
@@ -105,6 +106,7 @@ var/global/list/bad_blocks[0]
 	new_dna.b_type=b_type
 	new_dna.real_name=real_name
 	new_dna.species=species
+	new_dna.base_stability = base_stability
 	for(var/b=1;b<=DNA_SE_LENGTH;b++)
 		new_dna.SE[b]=SE[b]
 		if(b<=DNA_UI_LENGTH)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -240,7 +240,13 @@
 	else
 		H.real_name = R.dna.real_name
 
-	H.dna = R.dna.Clone()
+	// 15 damage at level 1 parts - "2" efficiency
+	// 0 damage at level 4 parts - "8" efficiency
+	var/datum/dna/newdna = R.dna.Clone()
+	newdna.base_stability -= max(15*((6-(efficiency - 2))/6), 0)
+	H.gene_stability = newdna.base_stability
+	H.dna = newdna
+
 
 	for(var/datum/language/L in R.languages)
 		H.add_language(L.name)


### PR DESCRIPTION
Cloning now causes permanent genetic instability - this can be mitigated by either upgrading the cloner (removed entirely at tier 4), or by keeping gene disk backups of the subject's DNA to clone them when the cloner is more sophisticated.
Do keep in mind that the cloner genetic instability change is mitigated by the negative mutations clones from low-tier cloners suffer from - meaning that in some cases, it may be wiser to skip the mutadone step, so that the patient may live.

At base level, patients are able to be cloned once without permanent detriment to everyday behavior. The permanent instability caused then drops as the cloner is upgraded, scaling linearly until tier 4 parts(scanners), where this is eliminated.

Hopefully, this should push medical to either not let patients die, or stick to more constrained/difficult, yet less punishing means of revival, such as the defib, or botany.

🆑Crazylemon
experiment: (another port) Cloning now reduces genetic stability each time someone is cloned. This can be mitigated by either keeping gene disks handy, or by upgrading the cloner's scanning unit.
/🆑